### PR TITLE
Add Company: dentro (Discovery)

### DIFF
--- a/src/data/market-map-data.json
+++ b/src/data/market-map-data.json
@@ -1,6 +1,6 @@
 {
   "title": "Agentic Commerce Market Map",
-  "totalCompanies": 215,
+  "totalCompanies": 216,
   "categories": {
     "User Interfaces": {
       "count": 6,
@@ -32,7 +32,7 @@
       ]
     },
     "Discovery": {
-      "count": 10,
+      "count": 11,
       "companies": [
         {
           "name": "x402jobs",
@@ -73,6 +73,10 @@
         {
           "name": "Valoria",
           "logoUrl": "https://x402.valoria.net/favicon.png"
+        },
+        {
+          "name": "dentro",
+          "logoUrl": "https://dentro.fyi/favicon.svg"
         }
       ]
     },


### PR DESCRIPTION
Adds dentro to the Discovery category. Tracks issue #11.

## Company

- **Name:** dentro
- **Website:** https://dentro.fyi
- **Logo:** https://dentro.fyi/favicon.svg (canonical doorway mark, ink panels + cyan dot, transparent background)
- **Category:** Discovery

## Short description

dentro is the agent-native commerce data layer for independent e-commerce. AI shopping agents query an x402-paid API to discover 22,000+ indie merchants across 16 countries (Shopify, WooCommerce, Magento, custom storefronts) and pull structured product data, prices, and stock without scraping or API keys. Pay-per-call USDC on Base mainnet.

## Why Discovery

The other 10 entries in Discovery are x402-native scanners, indexes, launch platforms, and job boards. dentro is the first commerce-data provider in the slot, focused on the long tail of independent stores that AI shopping agents currently can't see (everything outside Amazon, Walmart, etc.).

## Live links to verify

- 402 challenge sample: \`curl -i https://api.dentro.fyi/merchants\`
- agentic.market listing: https://api.agentic.market/v1/services/api-dentro-fyi
- Two real-money mainnet settlements yesterday confirm the API is live and paid: txs available on basescan.

Closes #11.